### PR TITLE
Updated chart dependency & unexisting template used in NOTES

### DIFF
--- a/ygqygq2/zipkin/Chart.yaml
+++ b/ygqygq2/zipkin/Chart.yaml
@@ -7,12 +7,12 @@ dependencies:
   - bitnami-common
   version: 1.x.x
 - name: elasticsearch
-  version: 17.x.x
+  version: 19.x.x
   repository: https://charts.bitnami.com/bitnami
   condition: elasticsearch.enabled
 description: Zipkin is a distributed tracing system.
 name: zipkin
-version: 2.1.1
+version: 2.1.2
 home: https://zipkin.io/
 icon: https://zipkin.io/public/img/logo_png/zipkin_vertical_grey_gb.png
 keywords:

--- a/ygqygq2/zipkin/templates/NOTES.txt
+++ b/ygqygq2/zipkin/templates/NOTES.txt
@@ -17,7 +17,7 @@ Zipkin can be accessed:
   * From outside the cluster, run these commands in the same shell:
     {{- if contains "NodePort" .Values.service.type }}
 
-    export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "zipkin.fullname" . }})
+    export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "zipkin.serviceAccountName" . }})
     export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
     echo http://$NODE_IP:$NODE_PORT
     {{- else if contains "LoadBalancer" .Values.service.type }}

--- a/ygqygq2/zipkin/templates/cronjob.yaml
+++ b/ygqygq2/zipkin/templates/cronjob.yaml
@@ -54,5 +54,5 @@ spec:
                   name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
               {{- end }}
             imagePullPolicy: {{ .Values.dependencies.image.pullPolicy }}
-            image: {{ .Values.dependencies.image.repository }}:{{ .Values.dependencies.image.tag }}
+            image: {{ .Values.global.imageRegistry }}/{{ .Values.dependencies.image.repository }}:{{ .Values.dependencies.image.tag }}
 {{- end -}}


### PR DESCRIPTION
#### PR Checklist
- [ ] Chart Version bumped
- [ ] CHANGELOG.md updated
- [ ] Variables and other changes are documented in the README.md


Fixes for  some problems when installing the chart, regarding a template that is used but doesn't exist inside NOTES.txt and a version bump for dependency charts due to some problem when installing the chart for 1st time and ```helm dependency build``` would fail